### PR TITLE
Fix staticfiles directory doesn't not exist error

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,8 @@
+from config.settings import settings
+from endpoints import members, messages, rooms, sync, threads
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-
 from starlette.middleware.cors import CORSMiddleware
-
-from config.settings import settings
-
-from endpoints import rooms, members, messages, threads, sync
-
 
 app = FastAPI(
     title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json"
@@ -39,4 +35,8 @@ app.include_router(
 )  # include urls from sync.py
 
 
-app.mount("/", StaticFiles(directory="../frontend/dist", html=True), name="static")
+app.mount(
+    "/",
+    StaticFiles(directory="../frontend/dist", html=True, check_dir=False),
+    name="static",
+)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,7 @@ distlib==0.3.3
 fastapi==0.70.0
 fastapi-pagination==0.9.0
 filelock==3.3.1
+gunicorn==20.1.0
 h11==0.12.0
 httpcore==0.13.7
 httptools==0.2.0
@@ -28,7 +29,7 @@ mccabe==0.6.1
 mypy-extensions==0.4.3
 nodeenv==1.6.0
 outcome==1.1.0
-packaging==21.0
+packaging==21.3
 pathspec==0.9.0
 platformdirs==2.4.0
 pluggy==1.0.0
@@ -52,7 +53,8 @@ tomli==1.2.2
 trio==0.19.0
 typing-extensions==3.10.0.2
 urllib3==1.26.7
-uvicorn[standard]
+uvicorn==0.15.0
+uvloop==0.16.0
 virtualenv==20.9.0
 watchgod==0.7
 websockets==10.0


### PR DESCRIPTION
The error occurred as there is no frontend/dist folder created yet and it prevents the server to run.

- Solved by setting check_dir parameter to False.
- There's still a RuntimeError as the dist folder is still not created but **the server can run now**.
(RuntimeError: StaticFiles directory '../frontend/dist' does not exist.)