### PR TITLE
BAC-25(https://linear.app/team-axe/issue/BAC-25/python-sdk-step-2)

### DIFF
--- a/backend/NovuPy/activity.py
+++ b/backend/NovuPy/activity.py
@@ -1,0 +1,45 @@
+import httpx
+
+from .settings import Core
+
+
+class Activity(Core):
+
+    async def get_activity(self, **kwargs):
+        """
+        Get activity feed
+
+        A page query parameter can be passed into the function to paginate response e.g page = 2  
+        Example response:
+
+        {
+            totalCount: 0,
+            data: ["data"],
+            pageSize: 0,
+            page: 0
+        }
+
+        """
+        url = self.base_url+'/activity'
+
+        async with httpx.AsyncClient() as requests:
+            response = await requests.get(url=url, headers=self.s_header, params=kwargs)
+
+        return response.json()
+
+    async def get_activity_stats(self):
+        """
+        Get activity statistics
+
+        Example response:
+        {
+            weeklySent: 0,
+            monthlySent: 0,
+            yearlySent: 0
+        }
+        """
+        url = self.base_url+'/activity/stats'
+        async with httpx.AsyncClient() as requests:
+            response = await requests.get(url=url, headers=self.s_header)
+
+        return response.json()

--- a/backend/NovuPy/events.py
+++ b/backend/NovuPy/events.py
@@ -1,0 +1,139 @@
+import httpx
+from fastapi import HTTPException, status
+
+from .settings import Core
+
+
+class Events(Core):
+
+    async def get_messages(self, **kwargs):
+        """
+        Returns a list of messages, could paginate using the `page` query parameter
+
+        The query can be passed to the function as a dict---> {page: 3}
+
+        Sample Response:
+        {
+            totalCount: 0,
+            data: ["data"],
+            pageSize: 0,
+            page: 0
+        }
+        """
+        url = self.base_url + f"/messages"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header, params=kwargs)
+
+        return response.json()
+
+    async def delete_message(self, message_id):
+        """
+        Deletes a message entity from the Novu platform
+        """
+        url = self.base_url + f"/messages/{message_id}"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.delete(url=url, headers=self.s_header)
+        return response.json()
+
+    async def trigger(self, event_name, data=None):
+        """
+        Trigger event is the main (and the only) way to send notification to subscribers. 
+        The trigger identifier is used to match the particular template associated with it. 
+        Additional information can be passed according the the body interface below.
+
+        To make a trigger: 
+
+            {
+                "name": "Novu",   
+                "payload": {                      
+                    "test": "test"
+                },
+                "to": {
+                        subscriberId: "<USER_IDENTIFIER>",
+                        email: "email@email.com",
+                        firstName: "John",
+                        lastName: "Doe",
+                }, 
+                "transactionId": "transactionId"  
+            }
+
+
+        name - #This refers to the name of the notification template you intend to use
+        payload - # The payload object is used to pass additional custom information that could be used to render the template, 
+                    or perform routing rules based on it. 
+                  #This data will also be available when fetching the notifications feed from the API to display certain parts of the UI.
+
+
+        to - # The recipients list of people who will receive the notification
+
+
+
+        transactionId- #A unique identifier for this transaction, a UUID will be generated if not provided.
+
+
+
+           Example response:
+
+        {
+            acknowledged: true,
+            status: "status",
+            transactionId: "transactionId"
+        }
+
+        """
+        url = self.base_url + "/events/trigger"
+
+        if not data:
+            data = {}
+        try:
+            data["name"] = event_name
+
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url=url, headers=self.headers, data=data)
+            return response.json()
+
+        except httpx.RequestError:
+            raise HTTPException(status_code=500, detail="Something went wrong")
+
+        except:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
+
+
+    async def broadcast(self, event_name, data=None):
+        """
+        Trigger a broadcast event to all existing subscribers, could be used to send announcements, etc. 
+        In the future could be used to trigger events to a subset of subscribers based on defined filters.
+        """
+        url = self.base_url + "/events/trigger/broadcast"
+
+        if not data:
+            data = {}
+        try:
+            data["name"] = event_name
+
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url=url, headers=self.headers, data=data)
+
+        except httpx.RequestError:
+            raise HTTPException(status_code=500, detail="Something went wrong")
+
+        except:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
+
+        return response.json()
+
+    async def cancel_trigger(self, transaction_id):
+        """
+        Using a previously generated transactionId during the event trigger, 
+        will cancel any active or pending workflows. 
+        This is useful to cancel active digests, delays etc...
+        """
+
+        url = self.base_url + f"/events/trigger/{transaction_id}"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.delete(url=url, headers=self.s_headers)
+
+        return response.json()

--- a/backend/NovuPy/feed.py
+++ b/backend/NovuPy/feed.py
@@ -1,0 +1,52 @@
+import httpx
+
+from .settings import Core
+
+
+class Feed(Core):
+    """
+    Track feed by passing {'name': name} 
+
+    Example Response:
+
+    {
+        _id: "_id",
+        name: "name",
+        identifier: "identifier",
+        _environmentId: "_environmentId",
+        _organizationId: "_organizationId"
+    }
+    """
+
+    async def get_feeds(self):
+        """
+        Get feed
+        """
+        url = self.base_url+'/feeds'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def create_feed(self, data=None):
+        """
+        Create Feed
+        """
+        url = self.base_url+'/feeds'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url=url, headers=self.header, data=data)
+
+        return response.json()
+
+    async def delete_feed(self, feed_id):
+        """
+        Create Feed
+        """
+        url = self.base_url+f'/feeds/{feed_id}'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.delete(url=url, headers=self.header)
+
+        return response.json()

--- a/backend/NovuPy/integrations.py
+++ b/backend/NovuPy/integrations.py
@@ -1,0 +1,91 @@
+import httpx
+
+from .settings import Core
+
+
+class Integration(Core):
+
+    """
+    Create Integrations such as Email, SMS, Push ...etc
+    by passing ...
+
+    {
+      "providerId": "providerId",
+      "channel": "channel",
+      "credentials": credentials,
+      "active": true
+    }
+
+    channel - indicate the channel to integrate(Email, SMS, Push ...etc)
+    credentials - necessary parameters to enbale connection should be provided in the credentials e.g API_KEY of the provider
+
+    Example Response:
+
+    {
+        _id: "_id",
+        _environmentId: "_environmentId",
+        _organizationId: "_organizationId",
+        providerId: "providerId",
+        channel: "channel",
+        credentials: credentials,
+        active: true,
+        deleted: true,
+        deletedAt: "deletedAt",
+        deletedBy: "deletedBy"
+    }
+    """
+
+    async def get_integrations(self):
+        """
+        Get integrations
+        """
+        url = self.base_url+'/integrations'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def get_active(self):
+        """
+        Get active integrations
+        """
+        url = self.base_url+'/integrations/active'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def create(self, data=None):
+        """
+        Create integration
+        """
+        url = self.base_url+'/integrations'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url=url, headers=self.headers, data=data)
+
+        return response.json()
+
+    async def update(self, id, data=None):
+        """
+        Update integration
+        """
+        url = self.base_url+f'/integrations/{id}'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.put(url=url, headers=self.headers, data=data)
+
+        return response.json()
+
+    async def delete(self, id):
+        """
+        Delete integration
+        """
+        url = self.base_url+f'/integrations/{id}'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.delete(url=url, headers=self.s_header)
+
+        return response.json()

--- a/backend/NovuPy/settings.py
+++ b/backend/NovuPy/settings.py
@@ -1,0 +1,35 @@
+from decouple import config
+
+BASE_URL = 'https://api.novu.co/v1'
+
+# declare NOVU_API_KEY in .env file
+# example:
+# NOVU_API_KEY = acc7708b8e05bc3f7d61dd629d320b41
+
+
+FULL_HEADER = {
+    'Authorization': 'ApiKey '+config('NOVU_API_KEY'),
+    'Content_Type': 'application/json'
+}
+
+# simple header with just Api_key
+SMALL_HEADER = {'Authorization': 'ApiKey ' +
+                config('NOVU_API_KEY', '')}
+
+
+class Core:
+
+    """
+    Generic configurations for all NovuPy modules can all be edited from here
+    """
+
+    def __init__(self) -> None:
+
+        self.base_url = BASE_URL
+
+        self.s_header = SMALL_HEADER
+
+        self.headers = FULL_HEADER
+
+
+core = Core()

--- a/backend/NovuPy/subscribers.py
+++ b/backend/NovuPy/subscribers.py
@@ -1,0 +1,203 @@
+import httpx
+from fastapi import HTTPException, status
+
+from .settings import Core
+
+
+class Subscribers(Core):
+
+    async def list(self, page=None):
+        """
+        Returns a list of subscribers, could be paginated using the `page` query parameter
+        """
+        url = self.base_url + \
+            f'/subscribers?page={page}' if page else self.base_url + \
+            f'/subscribers'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def identify(self, user_id, data=None):
+        """
+        Creates a subscriber entity, in the Novu platform. 
+        The subscriber will be later used to receive notifications, and access notification feeds.
+
+        A user_id must be passed, so that a correlating subscriberId will be created in Novu
+
+        This function will only create a Subscriber if it does not exist already
+
+        Sample data:
+
+
+        {
+            subscriberId: user.id
+            email: user.email,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            phone: user.phone,
+            avatar: user.profile_avatar
+        }
+
+        Response:
+
+        {
+            _id: "_id",
+            firstName: "firstName",
+            lastName: "lastName",
+            email: "email",
+            phone: "phone",
+            avatar: "avatar",
+            subscriberId: "subscriberId",
+            channels: ["channels"],
+            _organizationId: "_organizationId",
+            _environmentId: "_environmentId",
+            deleted: true,
+            createdAt: "createdAt",
+            updatedAt: "updatedAt",
+            __v: 0
+        }
+
+        """
+
+        url = self.base_url + '/subscribers'
+
+        if not data:
+            data = {}
+
+        try:
+            data['subscriberId'] = str(user_id)
+
+        except KeyError:
+            pass
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url=url, headers=self.headers, data=data)
+            return response.json()
+
+        except:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail="Could not subscribe user")
+
+    async def get_subscriber(self, subscriber_id):
+        """
+        Get subscriber by your internal id used to identify the subscriber
+        """
+
+        url = self.base_url + f'/subscribers/{subscriber_id}'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def update_subscriber(self, subscriber_id, data=None):
+        """
+        Used to update the subscriber entity with new information
+        """
+
+        url = self.base_url + f'/subscribers/{subscriber_id}'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.put(url=url, headers=self.headers, data=data)
+
+        return response.json()
+
+    async def delete_subscriber(self, subscriber_id):
+        """
+        Deletes a subscriber entity from the Novu platform
+        """
+
+        url = self.base_url + f'/subscribers/{subscriber_id}'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.delete(url=url, headers=self.headers)
+
+        return response.json()
+
+    async def update_subscriber_credentials(self, subscriber_id, data=None):
+        """
+        Subscriber credentials associated to the delivery methods such as slack and push tokens.
+        """
+        url = self.base_url + f'/subscribers/{subscriber_id}/credentials'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.put(url=url, headers=self.headers, data=data)
+
+        return response.json()
+
+    async def get_subscriber_preferences(self, subscriber_id):
+        """
+        Get subscriber preferences
+        """
+        url = self.base_url + f'/subscribers/{subscriber_id}/preferences'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def update_subscriber_preferences(self, subscriber_id, template_id, data=None):
+        """
+        Update subscriber preference
+        """
+
+        url = self.base_url + \
+            f'/subscribers/{subscriber_id}/preferences/{template_id}'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.patch(url=url, headers=self.headers, data=data)
+
+        return response.json()
+
+    async def get_notifications_feed(self, subscriber_id, **kwargs):
+        """
+        Get a notification feed for a particular subscriber
+        """
+        url = self.base_url + \
+            f'/subscribers/{subscriber_id}/notifications/feed'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def get_unseen_notifications_count(self, subscriber_id, **kwargs):
+        """
+        Get the unseen notification count for subscribers feed
+        """
+
+        url = self.base_url + \
+            f'/subscribers/{subscriber_id}/notifications/unseen'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def mark_message_seen(self, subscriber_id, message_id):
+
+        """
+        Mark a subscriber feed message as seen
+        """
+        url = self.base_url + \
+            f'subscribers/{subscriber_id}/messages/{message_id}/seen'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url=url, headers=self.s_header)
+
+        return response.json()
+
+    async def mark_action_seen(self, subscriber_id, message_id, type):
+        """
+        Mark message action as seen
+        """
+        url = self.base_url + \
+            f'subscribers/{subscriber_id}/messages/{message_id}/actions/{type}'
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url=url, headers=self.s_header)
+
+        return response.json()


### PR DESCRIPTION
NovuPy (_Python SDK for Novu_) covers major endpoints and functionalities of the Novu Notification system.
[Link to Linear](https://linear.app/team-axe/issue/BAC-25/python-sdk-step-2)
- Events
- Subscribers
- Activity
- Integrations
- Feeds  

All others can be configured from the admin page of the Novu Instance

The url of the hosted Novu Instance can be configured in the settings module.
The `NOVU_API_KEY` should be inside a `.env` file

As of this moment, no live link has been provided to me. 
But the SDK can still be tested by calling the function and passing required data.

For additional information on how to use the NovuPy  [click here](https://docs.novu.co/api/trigger-event/)