### PR TITLE
Feat: FRO-76/ Create a new thread through reply Icon

### DIFF
--- a/frontend/zc_messaging/src/pages/message-board/MessageBoard.style.js
+++ b/frontend/zc_messaging/src/pages/message-board/MessageBoard.style.js
@@ -6,6 +6,7 @@ export const Container = styled.main`
   padding-top: 1.93rem;
   gap: 8px;
   background: #f9f9f9;
+  position: relative;
 `
 
 export const MessagingArea = styled.div`

--- a/frontend/zc_messaging/src/pages/message-board/index.jsx
+++ b/frontend/zc_messaging/src/pages/message-board/index.jsx
@@ -236,7 +236,7 @@ const MessagingBoard = () => {
               onReact={reactHandler}
               onSendAttachedFile={SendAttachedFileHandler}
               currentUserId={authUser?.user_id}
-              height={"100vh"}
+              height={"92vh"}
             />
           </div>
           {/* <TypingNotice>Omo Jesu is typing</TypingNotice> */}

--- a/frontend/zc_messaging/src/pages/message-board/index.jsx
+++ b/frontend/zc_messaging/src/pages/message-board/index.jsx
@@ -236,6 +236,7 @@ const MessagingBoard = () => {
               onReact={reactHandler}
               onSendAttachedFile={SendAttachedFileHandler}
               currentUserId={authUser?.user_id}
+              height={"100vh"}
             />
           </div>
           {/* <TypingNotice>Omo Jesu is typing</TypingNotice> */}

--- a/frontend/zc_messaging/src/routes/index.jsx
+++ b/frontend/zc_messaging/src/routes/index.jsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Routes, Route } from "react-router-dom"
 import { ThreadBar, UserProfileBar, ChannelDetails } from "../component"
 import { ChannelBrowser, DmBrowser, MessagingBoard, Threads } from "../pages"
+import { CommentBoard } from "@zuri/ui"
 
 /**
  * Main Routing for the zc messaging plugin.
@@ -11,7 +12,12 @@ const AppRoutes = () => (
   <Routes>
     <Route path="/" element={<MessagingBoard />} />
     <Route path="/:roomId" element={<MessagingBoard />}>
-      <Route path="thread/:threadId" element={<ThreadBar />} />
+      <Route
+        path="thread/:threadId"
+        element={
+          <CommentBoard commentBoardConfig={{ displayCommentBoard: true }} />
+        }
+      />
       <Route path="member-profile/:memberId" element={<UserProfileBar />} />
       <Route path="channel-details/:channelId" element={<ChannelDetails />} />
     </Route>


### PR DESCRIPTION
This adds a comment board when thread is opened
Linear-Ticket: https://linear.app/team-bevel/issue/FRO-76/create-a-new-thread-through-reply-icon-right
https://user-images.githubusercontent.com/60897319/203923263-2518d63b-7265-491c-b89b-d2951a60b502.mp4

