### PR TITLE
fix(BAC-49):implemented custom pagination

### DIFF
--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -272,11 +272,12 @@ async def get_messages(org_id: str, room_id: str, page: int = 1, limit: int = 15
         )
 
     result = {
-            "status": "success",
-            "message": "Messages retrieved",
             "data": response,
             "page": page,
             "size": limit
     }
-    return result
 
+    return JSONResponse(
+        content=ResponseModel.success(data=result, message="Messages retrieved"),
+        status_code=status.HTTP_200_OK,
+    )

--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -216,11 +216,11 @@ async def update_message(
 
 @router.get(
     "/org/{org_id}/rooms/{room_id}/messages",
-    response_model=Page[Message],
+    response_model=[].append(Message),
     status_code=status.HTTP_200_OK,
     responses={424: {"detail": "ZC Core failed"}},
 )
-async def get_messages(org_id: str, room_id: str):
+async def get_messages(org_id: str, room_id: str, page: int = 1, limit: int = 15):
     """Fetches all messages sent in a particular room.
 
     Args:
@@ -258,7 +258,7 @@ async def get_messages(org_id: str, room_id: str):
         HTTPException [424]: Zc Core failed
     """
 
-    response = await get_room_messages(org_id, room_id)
+    response = await get_room_messages(org_id, room_id, page, limit)
     if response == []:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -271,6 +271,4 @@ async def get_messages(org_id: str, room_id: str):
             detail="Zc Core failed",
         )
 
-    return paginate(response)
-
-add_pagination(router)
+    return response

--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -271,4 +271,12 @@ async def get_messages(org_id: str, room_id: str, page: int = 1, limit: int = 15
             detail="Zc Core failed",
         )
 
-    return response
+    result = {
+            "status": "success",
+            "message": "Messages retrieved",
+            "data": response,
+            "page": page,
+            "size": limit
+    }
+    return result
+

--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -3,9 +3,10 @@ from typing import Any, Optional
 from config.settings import settings
 from schema.message import Message
 from utils.db import DataStorage
+from utils.paginator import off_set
 
 
-async def get_org_messages(org_id: str) -> Optional[list[dict[str, Any]]]:
+async def get_org_messages(org_id: str, page: int, limit: int) -> Optional[list[dict[str, Any]]]:
     """Gets all messages sent in  an organization.
 
     Args:
@@ -32,7 +33,9 @@ async def get_org_messages(org_id: str) -> Optional[list[dict[str, Any]]]:
     """
 
     DB = DataStorage(org_id)
-    response = await DB.read(settings.MESSAGE_COLLECTION)
+    skip = await off_set(page, limit)
+    options = {"limit":limit, "skip":skip, "sort":{"_id":-1}}
+    response = await DB.read(settings.MESSAGE_COLLECTION, options=options)
 
     if not response or "status_code" in response:
         return None
@@ -41,7 +44,7 @@ async def get_org_messages(org_id: str) -> Optional[list[dict[str, Any]]]:
 
 
 async def get_room_messages(
-    org_id: str, room_id: str
+    org_id: str, room_id: str, page: int, limit: int
 ) -> Optional[list[dict[str, Any]]]:
     """Gets all messages sent inside  a room.
     Args:
@@ -69,7 +72,9 @@ async def get_room_messages(
     """
 
     DB = DataStorage(org_id)
-    response = await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id})
+    skip = await off_set(page, limit)
+    options = {"limit":limit, "skip":skip, "sort":{"_id":-1}}
+    response = await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id}, options=options)
 
     if response is None:
         return []
@@ -81,7 +86,7 @@ async def get_room_messages(
 
 
 async def get_message(
-    org_id: str, room_id: str, message_id: str
+    org_id: str, room_id: str, message_id: str, page: int, limit: int
 ) -> Optional[dict[str, Any]]:
     """Get a specific message in a room.
 
@@ -110,8 +115,11 @@ async def get_message(
     """
 
     DB = DataStorage(org_id)
+    
+    skip = await off_set(page, limit)
     query = {"room_id": room_id, "_id": message_id}
-    response = await DB.read(settings.MESSAGE_COLLECTION, query=query)
+    options = {"limit":limit, "skip":skip, "sort":{"_id":-1}}
+    response = await DB.read(settings.MESSAGE_COLLECTION, query=query,  options=options)
 
     if not response or "status_code" in response:
         return {}

--- a/backend/utils/paginator.py
+++ b/backend/utils/paginator.py
@@ -1,0 +1,2 @@
+async def off_set(page: int, limit: int):
+    return (page-1)*limit


### PR DESCRIPTION
Task: 
Implement progressive requesting of data and old chats so it does not load all of history. This goes for DMs and Channel Chats. (Zuri Project 2)

[Linear link](https://linear.app/team-gear/issue/BAC-49/zuri-chat-task)

Solution:
Implemented a custom pagination query to get data in batches (of 15) from the database with @bolexs.

Result:
![image](https://user-images.githubusercontent.com/82163647/204042208-f6760101-1ae0-49b5-b67d-760349d39c00.png)
(note|: limit and page are optional query parameters; when not specified page=1 and limit=15)

**New Edit:
The parameters are now page & size not page & limit**

![image](https://user-images.githubusercontent.com/82163647/204043062-cf8223bd-16e6-4dd8-bdfc-a631ee1de4e3.png)
![image](https://user-images.githubusercontent.com/82163647/204043015-3db78f84-4fb1-4915-ab09-2fad1a99c6e9.png)


Please review:
@zxenonx @AI-fae @mykie88 
