### PR TITLE
Fix:FE adds query parameters to fetch room messages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "jest-cli": "^27.0.6",
     "lint-staged": ">=10",
     "opener": "^1.5.2",
-    "prettier": "^2.8.0",
+    "prettier": "^2.3.2",
     "pretty-quick": "^3.1.1",
     "rimraf": "^3.0.2",
     "serve": "^12.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "jest-cli": "^27.0.6",
     "lint-staged": ">=10",
     "opener": "^1.5.2",
-    "prettier": "^2.3.2",
+    "prettier": "^2.8.0",
     "pretty-quick": "^3.1.1",
     "rimraf": "^3.0.2",
     "serve": "^12.0.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3967,10 +3967,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.3.2:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.0.tgz#c7df58393c9ba77d6fba3921ae01faf994fb9dc9"
+  integrity sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==
 
 pretty-format@^27.3.1:
   version "27.3.1"

--- a/frontend/zc_messaging/src/pages/message-board/message-board.utils.js
+++ b/frontend/zc_messaging/src/pages/message-board/message-board.utils.js
@@ -41,11 +41,11 @@ const sendMessageBoardHandler = async (
  * @description Retrieve all room messages
  */
 
-const getRoomMessagesHandler = async (orgId, roomId) => {
+const getRoomMessagesHandler = async (orgId, roomId, page = 1, size = 50) => {
   try {
     if (orgId && roomId) {
       const getRoomMessagesResponse = await axios.get(
-        `${BASE_URL}/org/${orgId}/rooms/${roomId}/messages`
+        `${BASE_URL}/org/${orgId}/rooms/${roomId}/messages?page=${page}&size=${size}`
       )
       return getRoomMessagesResponse.data
     }


### PR DESCRIPTION
### **Linear Ticket**

My PR Fixes [Linear Ticket](https://linear.app/team-gear/issue/GG-23/solve-scrolling-issue-in-the-main-chat-area)

### Requested Changes 
There are currently scroll issues on ZuriChat with the main chat area. It needs to be fixed to behave like Slack (not scrolling everytime you go in). Also, progressive requesting of data and old chats should be done, so it does not load all of history.

### My fix
On the backend, pagination was implemented to fetch messages in batches, with a default size of 50 messages per page. On the frontend, I added the following query parameters: page and size. Page with a default value of 1 and size with a default value of 50.

@zxenonx 

