### PR TITLE
Fix/bac 49 custom pagination

### DIFF
--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -6,7 +6,7 @@ from utils.db import DataStorage
 from utils.paginator import off_set
 
 
-async def get_org_messages(org_id: str, page: int, limit: int) -> Optional[list[dict[str, Any]]]:
+async def get_org_messages(org_id: str, page: int, size: int) -> Optional[list[dict[str, Any]]]:
     """Gets all messages sent in  an organization.
 
     Args:
@@ -33,8 +33,8 @@ async def get_org_messages(org_id: str, page: int, limit: int) -> Optional[list[
     """
 
     DB = DataStorage(org_id)
-    skip = await off_set(page, limit)
-    options = {"limit":limit, "skip":skip, "sort":{"_id":-1}}
+    skip = await off_set(page, size)
+    options = {"limit":size, "skip":skip, "sort":{"_id":-1}}
     response = await DB.read(settings.MESSAGE_COLLECTION, options=options)
 
     if not response or "status_code" in response:
@@ -44,7 +44,7 @@ async def get_org_messages(org_id: str, page: int, limit: int) -> Optional[list[
 
 
 async def get_room_messages(
-    org_id: str, room_id: str, page: int, limit: int
+    org_id: str, room_id: str, page: int, size: int
 ) -> Optional[list[dict[str, Any]]]:
     """Gets all messages sent inside  a room.
     Args:
@@ -73,8 +73,8 @@ async def get_room_messages(
     DB = DataStorage(org_id)
 
     
-    skip = await off_set(page, limit)
-    options = {"limit":limit, "skip":skip, "sort":{"_id":-1}}
+    skip = await off_set(page, size)
+    options = {"limit":size, "skip":skip, "sort":{"_id":-1}}
     response = await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id}, options=options)
     
 

--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -70,11 +70,13 @@ async def get_room_messages(
             ...
         ]
     """
-
     DB = DataStorage(org_id)
+
+    
     skip = await off_set(page, limit)
     options = {"limit":limit, "skip":skip, "sort":{"_id":-1}}
     response = await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id}, options=options)
+    
 
     if response is None:
         return []

--- a/backend/utils/paginator.py
+++ b/backend/utils/paginator.py
@@ -1,8 +1,8 @@
 from utils.db import DataStorage
 from config.settings import settings
 
-async def off_set(page: int, limit: int):
-    return (page-1)*limit
+async def off_set(page: int, size: int):
+    return (page-1)*size
 
 
 async def page_urls(page: int, size: int, org_id : int, room_id: int, endpoint: str):

--- a/backend/utils/paginator.py
+++ b/backend/utils/paginator.py
@@ -1,2 +1,26 @@
+from utils.db import DataStorage
+from config.settings import settings
+
 async def off_set(page: int, limit: int):
     return (page-1)*limit
+
+
+async def page_urls(page: int, size: int, org_id : int, room_id: int, endpoint: str):
+
+    DB = DataStorage(org_id)
+    total_count = len(await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id}))
+
+    paging = {}
+
+    if (size + await off_set(page, size)) >= total_count:
+        paging['next'] = None
+    else:
+        paging['next'] = f"{endpoint}?page={page+1}&size={size}"
+
+
+    if page > 1:
+        paging['previous'] = f"{endpoint}?page={page-1}&size={size}"
+    else:
+        paging['previous'] = None
+
+    return paging, total_count


### PR DESCRIPTION
Implemented suggestions from reviewers of last pull request.
Added more pagination information to response for frontend to consume such as:
1. total number of items in db
2. pointer to the next page
3. pointer to the previous page
with @bolexs 

[Linear Link](https://linear.app/team-gear/issue/BAC-49/zuri-chat-task)

![image](https://user-images.githubusercontent.com/82163647/204374375-cf80c586-1cde-4171-943c-1238f924ec4f.png)

Please review:
@AI-fae @mikengr  @zxenonx 