### PR TITLE
added prev and next pointers to the response for get_messages endpoint

### DIFF
--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -6,6 +6,7 @@ from starlette.responses import JSONResponse
 from utils.centrifugo import Events, centrifugo_client
 from utils.message_utils import create_message, get_message, get_room_messages
 from utils.message_utils import update_message as edit_message
+from utils.paginator import page_urls
 
 router = APIRouter()
 
@@ -220,7 +221,7 @@ async def update_message(
     status_code=status.HTTP_200_OK,
     responses={424: {"detail": "ZC Core failed"}},
 )
-async def get_messages(org_id: str, room_id: str, page: int = 1, limit: int = 15):
+async def get_messages(org_id: str, room_id: str, page: int = 1, size: int = 15):
     """Fetches all messages sent in a particular room.
 
     Args:
@@ -258,7 +259,8 @@ async def get_messages(org_id: str, room_id: str, page: int = 1, limit: int = 15
         HTTPException [424]: Zc Core failed
     """
 
-    response = await get_room_messages(org_id, room_id, page, limit)
+    response = await get_room_messages(org_id, room_id, page, size)
+    paging, total_count = await page_urls(page, size, org_id, room_id, endpoint=f"/api/v1/org/{org_id}/rooms/{room_id}/messages")
     if response == []:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -271,7 +273,14 @@ async def get_messages(org_id: str, room_id: str, page: int = 1, limit: int = 15
             detail="Zc Core failed",
         )
 
-    result = {"data": response, "page": page, "size": limit}
+    result = {
+            "data": response,
+            "page": page,
+            "size": size,
+            "total": total_count,
+            "previous": paging.get('previous'),
+            "next": paging.get('next')         
+    }
 
     return JSONResponse(
         content=ResponseModel.success(data=result, message="Messages retrieved"),

--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -6,7 +6,7 @@ from utils.db import DataStorage
 from utils.paginator import off_set
 
 
-async def get_org_messages(org_id: str, page: int, limit: int) -> Optional[list[dict[str, Any]]]:
+async def get_org_messages(org_id: str, page: int, size: int) -> Optional[list[dict[str, Any]]]:
     """Gets all messages sent in  an organization.
 
     Args:
@@ -33,8 +33,8 @@ async def get_org_messages(org_id: str, page: int, limit: int) -> Optional[list[
     """
 
     DB = DataStorage(org_id)
-    skip = await off_set(page, limit)
-    options = {"limit":limit, "skip":skip, "sort":{"_id":-1}}
+    skip = await off_set(page, size)
+    options = {"limit":size, "skip":skip, "sort":{"_id":-1}}
     response = await DB.read(settings.MESSAGE_COLLECTION, options=options)
 
     if not response or "status_code" in response:
@@ -44,7 +44,7 @@ async def get_org_messages(org_id: str, page: int, limit: int) -> Optional[list[
 
 
 async def get_room_messages(
-    org_id: str, room_id: str, page: int, limit: int
+    org_id: str, room_id: str, page: int, size: int
 ) -> Optional[list[dict[str, Any]]]:
     """Gets all messages sent inside  a room.
     Args:
@@ -72,8 +72,9 @@ async def get_room_messages(
     """
 
     DB = DataStorage(org_id)
-    skip = await off_set(page, limit)
-    options = {"limit":limit, "skip":skip, "sort":{"_id":-1}}
+    
+    skip = await off_set(page, size)
+    options = {"limit":size, "skip":skip, "sort":{"_id":-1}}
     response = await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id}, options=options)
 
     if response is None:

--- a/backend/utils/paginator.py
+++ b/backend/utils/paginator.py
@@ -1,2 +1,26 @@
-async def off_set(page: int, limit: int):
-    return (page-1)*limit
+from utils.db import DataStorage
+from config.settings import settings
+
+async def off_set(page: int, size: int):
+    return (page-1)*size
+
+
+async def page_urls(page: int, size: int, org_id : int, room_id: int, endpoint: str):
+
+    DB = DataStorage(org_id)
+    total_count = len(await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id}))
+
+    paging = {}
+
+    if (size + await off_set(page, size)) >= total_count:
+        paging['next'] = None
+    else:
+        paging['next'] = f"{endpoint}?page={page+1}&size={size}"
+
+
+    if page > 1:
+        paging['previous'] = f"{endpoint}?page={page-1}&size={size}"
+    else:
+        paging['previous'] = None
+
+    return paging, total_count


### PR DESCRIPTION
Implemented suggestions from reviewers of last pull request.
Added more pagination information to response for frontend to consume such as:


1. total number of items in db
2. pointer to the next page
3. pointer to the previous page

[Linear Link](https://linear.app/team-gear/issue/GG-30/solve-zuri-chat-backend)

![image](https://user-images.githubusercontent.com/82163647/205059131-10219393-106f-471c-a81a-216da8bb1be4.png)

