### PR TITLE
Feat/bac 26 trigger messages events

### DIFF
--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -6,9 +6,10 @@ from starlette.responses import JSONResponse
 from utils.centrifugo import Events, centrifugo_client
 from utils.message_utils import create_message, get_message, get_room_messages
 from utils.message_utils import update_message as edit_message
+from utils.chat_notification import Notification
 
 router = APIRouter()
-
+notification = Notification()
 
 @router.post(
     "/org/{org_id}/rooms/{room_id}/messages",
@@ -88,7 +89,7 @@ async def send_message(
         )
 
     message.message_id = response["data"]["object_id"]
-
+    user_msg_notification = await notification.messages_trigger(message_obj=message)
     # Publish to centrifugo in the background.
     background_tasks.add_task(
         centrifugo_client.publish,

--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -208,6 +208,10 @@ async def update_message(
     background_tasks.add_task(
         centrifugo_client.publish, room_id, Events.MESSAGE_UPDATE, message
     )
+    
+    # instantiate the Notication's function that handles message notification
+    user_msg_notification = await notification.messages_trigger(message_obj=message)
+	
 
     return JSONResponse(
         content=ResponseModel.success(data=message, message="Message edited"),

--- a/backend/endpoints/rooms.py
+++ b/backend/endpoints/rooms.py
@@ -9,10 +9,10 @@ from utils.centrifugo import Events, centrifugo_client
 from utils.db import DataStorage
 from utils.room_utils import get_room, remove_room_member,remove_room
 from utils.sidebar import sidebar
-from utils.chat_notification import Notification
+
 
 router = APIRouter()
-notification = Notification()
+
 
 @router.post(
     "/org/{org_id}/members/{member_id}/rooms",
@@ -54,7 +54,6 @@ async def create_room(
             "starred": False,
             "closed": False,
         }
-    novu_dm_subscriber = await notification.dm_subscriber_create(room_obj=room_obj)
     response = await DB.write(settings.ROOM_COLLECTION, data=room_obj.dict())
     if response and response.get("status_code", None) is None:
         room_id = {"room_id": response.get("data").get("object_id")}
@@ -243,7 +242,6 @@ async def join_room(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="only existing members can add new members",
             )
-    novu_subscriber_create = await notification.channel_subcriber_create(member_id=member)
     if room["room_type"].upper() == RoomType.CHANNEL:
         if room["is_private"] is True and (member["role"].lower() != Role.ADMIN):
             raise HTTPException(

--- a/backend/endpoints/rooms.py
+++ b/backend/endpoints/rooms.py
@@ -9,9 +9,10 @@ from utils.centrifugo import Events, centrifugo_client
 from utils.db import DataStorage
 from utils.room_utils import get_room, remove_room_member,remove_room
 from utils.sidebar import sidebar
+from utils.chat_notification import Notification
 
 router = APIRouter()
-
+notification = Notification()
 
 @router.post(
     "/org/{org_id}/members/{member_id}/rooms",
@@ -53,7 +54,7 @@ async def create_room(
             "starred": False,
             "closed": False,
         }
-
+    novu_dm_subscriber = await notification.dm_subscriber_create(room_obj=room_obj)
     response = await DB.write(settings.ROOM_COLLECTION, data=room_obj.dict())
     if response and response.get("status_code", None) is None:
         room_id = {"room_id": response.get("data").get("object_id")}
@@ -236,14 +237,13 @@ async def join_room(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="room not found" if not room else "DM room cannot be joined",
         )
-
     member = room.get("room_members").get(str(member_id))
     if member == None:
         raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="only existing members can add new members",
             )
-
+    novu_subscriber_create = await notification.channel_subcriber_create(member_id=member)
     if room["room_type"].upper() == RoomType.CHANNEL:
         if room["is_private"] is True and (member["role"].lower() != Role.ADMIN):
             raise HTTPException(


### PR DESCRIPTION
**This PR implements triggering of notifications when messages are sent.** 
The code changes do the following

Create a subscriber profile on the notification server to every member in a room when message is sent to that room
Publishes notification events to the notification server to be sent to the subscribers.
This builds on the work done in https://github.com/zurichat/zc_messaging/pull/141, https://github.com/zurichat/zc_messaging/pull/140 and https://github.com/zurichat/zc_messaging/pull/138, making notifications functional

Note
When a message notification is sent, Novu automatically subscribes the user if such user doesn't exist