### PR TITLE
Feat/gg 32 zuri chat filtering

### DIFF
--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -102,10 +102,14 @@ async def send_message(
         message.dict(),
     )
     # instantiate the Notication's function that handles message notification
+<<<<<<< HEAD
     try:
         await notification.messages_trigger(message_obj=message)
     except Exception as e:
         print("Novu message error", e)
+=======
+    user_msg_notification = await notification.messages_trigger(message_obj=message)
+>>>>>>> e68aa2f (feat(GG-32): Implemented filtering at the backend for zuri chat)
 
     return JSONResponse(
         content=ResponseModel.success(data=message.dict(), message="new message sent"),
@@ -293,13 +297,13 @@ async def get_messages(
         )
 
     result = {
-        "data": response,
-        "created_at": created_at,
-        "page": page,
-        "size": size,
-        "total": total_count,
-        "previous": paging.get("previous"),
-        "next": paging.get("next"),
+            "data": response,
+            "created_at": created_at,
+            "page": page,
+            "size": size,
+            "total": total_count,
+            "previous": paging.get('previous'),
+            "next": paging.get('next')
     }
 
     return JSONResponse(

--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -102,14 +102,10 @@ async def send_message(
         message.dict(),
     )
     # instantiate the Notication's function that handles message notification
-<<<<<<< HEAD
     try:
         await notification.messages_trigger(message_obj=message)
     except Exception as e:
         print("Novu message error", e)
-=======
-    user_msg_notification = await notification.messages_trigger(message_obj=message)
->>>>>>> e68aa2f (feat(GG-32): Implemented filtering at the backend for zuri chat)
 
     return JSONResponse(
         content=ResponseModel.success(data=message.dict(), message="new message sent"),

--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -108,8 +108,7 @@ async def send_message(
         print("Novu message error", e)
 
     return JSONResponse(
-        content=ResponseModel.success(
-            data=message.dict(), message="new message sent"),
+        content=ResponseModel.success(data=message.dict(), message="new message sent"),
         status_code=status.HTTP_201_CREATED,
     )
 
@@ -231,7 +230,9 @@ async def update_message(
     status_code=status.HTTP_200_OK,
     responses={424: {"detail": "ZC Core failed"}},
 )
-async def get_messages(org_id: str, room_id: str, page: int = 1, size: int = 15):
+async def get_messages(
+    org_id: str, room_id: str, page: int = 1, size: int = 15, created_at: int = None
+):
     """Fetches all messages sent in a particular room.
 
     Args:
@@ -269,8 +270,16 @@ async def get_messages(org_id: str, room_id: str, page: int = 1, size: int = 15)
         HTTPException [424]: Zc Core failed
     """
 
-    response = await get_room_messages(org_id, room_id, page, size)
-    paging, total_count = await page_urls(page, size, org_id, room_id, endpoint=f"/api/v1/org/{org_id}/rooms/{room_id}/messages")
+    response = await get_room_messages(org_id, room_id, page, size, created_at)
+
+    paging, total_count = await page_urls(
+        page,
+        size,
+        org_id,
+        room_id,
+        endpoint=f"/api/v1/org/{org_id}/rooms/{room_id}/messages",
+    )
+
     if response == []:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -285,15 +294,15 @@ async def get_messages(org_id: str, room_id: str, page: int = 1, size: int = 15)
 
     result = {
         "data": response,
+        "created_at": created_at,
         "page": page,
         "size": size,
         "total": total_count,
-        "previous": paging.get('previous'),
-        "next": paging.get('next')
+        "previous": paging.get("previous"),
+        "next": paging.get("next"),
     }
 
     return JSONResponse(
-        content=ResponseModel.success(
-            data=result, message="Messages retrieved"),
+        content=ResponseModel.success(data=result, message="Messages retrieved"),
         status_code=status.HTTP_200_OK,
     )

--- a/backend/utils/db.py
+++ b/backend/utils/db.py
@@ -189,6 +189,7 @@ class DataStorage:
         resource_id: Optional[str] = None,
         query: Optional[dict[str, Any]] = None,
         options: Optional[dict[str, Any]] = None,
+        raw_query: Optional [dict[str, Any]] = None
     ) -> Any:
         """Reads data from zc_messaging collections.
 
@@ -238,6 +239,7 @@ class DataStorage:
             "object_id": resource_id,
             "filter": query,
             "options": options,
+            "raw_query": raw_query
         }
 
         try:

--- a/backend/utils/db.py
+++ b/backend/utils/db.py
@@ -1,10 +1,9 @@
 from typing import Any, Optional
 
 import requests
+from config.settings import settings
 from fastapi import status
 from fastapi.exceptions import HTTPException
-
-from config.settings import settings
 
 
 class DataStorage:

--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -1,5 +1,7 @@
+import datetime
+import json
 from typing import Any, Optional
-import datetime, json
+
 from config.settings import settings
 from schema.message import Message
 from utils.db import DataStorage
@@ -53,7 +55,7 @@ async def get_room_messages(
     #timestamp: int = None,
     created_at: int = None,
 ) -> Optional[list[dict[str, Any]]]:
-    
+
     """Gets all messages sent inside  a room.
     Args:
         org_id (str): The organization id
@@ -88,22 +90,22 @@ async def get_room_messages(
         date = datetime.datetime.now() - datetime.timedelta(days=created_at)
         raw_query ={ "room_id": room_id, "created_at": { "$gte":str(date).split()[0]} }
     else:
-        
+
         raw_query = {"room_id": room_id}
-        
+
     print(raw_query)
     response = await DB.read(
         settings.MESSAGE_COLLECTION,
         options=options,
         raw_query=raw_query,
     )
-    
+
     if response is None:
         return []
-    
+
     if "status_code" in response:
         return None
-    
+
     return response
 
 

--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -1,7 +1,5 @@
 import datetime
-import json
 from typing import Any, Optional
-
 from config.settings import settings
 from schema.message import Message
 from utils.db import DataStorage
@@ -52,7 +50,6 @@ async def get_room_messages(
     room_id: str,
     page: int,
     size: int,
-    #timestamp: int = None,
     created_at: int = None,
 ) -> Optional[list[dict[str, Any]]]:
 
@@ -86,7 +83,7 @@ async def get_room_messages(
     skip = await off_set(page, size)
     options = {"limit": size, "skip": skip, "sort": { "created_at": 1}}
     raw_query = {}
-    if created_at != None:
+    if created_at:
         date = datetime.datetime.now() - datetime.timedelta(days=created_at)
         raw_query ={ "room_id": room_id, "created_at": { "$gte":str(date).split()[0]} }
     else:

--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -90,10 +90,7 @@ async def get_room_messages(
         date = datetime.datetime.now() - datetime.timedelta(days=created_at)
         raw_query ={ "room_id": room_id, "created_at": { "$gte":str(date).split()[0]} }
     else:
-
         raw_query = {"room_id": room_id}
-
-    print(raw_query)
     response = await DB.read(
         settings.MESSAGE_COLLECTION,
         options=options,

--- a/backend/utils/paginator.py
+++ b/backend/utils/paginator.py
@@ -1,5 +1,6 @@
-from utils.db import DataStorage
 from config.settings import settings
+from utils.db import DataStorage
+
 
 async def off_set(page: int, size: int):
     return (page - 1) * size

--- a/backend/utils/paginator.py
+++ b/backend/utils/paginator.py
@@ -2,25 +2,26 @@ from utils.db import DataStorage
 from config.settings import settings
 
 async def off_set(page: int, size: int):
-    return (page-1)*size
+    return (page - 1) * size
 
 
-async def page_urls(page: int, size: int, org_id : int, room_id: int, endpoint: str):
+async def page_urls(page: int, size: int, org_id: int, room_id: int, endpoint: str):
 
     DB = DataStorage(org_id)
-    total_count = len(await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id}))
+    total_count = len(
+        await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id})
+    )
 
     paging = {}
 
     if (size + await off_set(page, size)) >= total_count:
-        paging['next'] = None
+        paging["next"] = None
     else:
-        paging['next'] = f"{endpoint}?page={page+1}&size={size}"
-
+        paging["next"] = f"{endpoint}?page={page+1}&size={size}"
 
     if page > 1:
-        paging['previous'] = f"{endpoint}?page={page-1}&size={size}"
+        paging["previous"] = f"{endpoint}?page={page-1}&size={size}"
     else:
-        paging['previous'] = None
+        paging["previous"] = None
 
     return paging, total_count


### PR DESCRIPTION
feat(GG-32-implement-zuri-chat-filtering) [linear link](https://linear.app/team-gear/issue/GG-32/implement-zuri-chat-filtering-in-the-backend)

1. created the filtering feature at the backend to accept a value and convert the value to a stringdate
![created_at__](https://user-images.githubusercontent.com/65228354/206710915-d5a522af-1cbb-4bf9-ba5c-9016f6f3b8c2.png)

2. Modified the sort to use 

> `"sort": { "created_at": 1}`
instead of the intial code which was `"sort": { "_id": -1}`

**Reason**: -1 starts from newest to oldest, 1 start from oldest to newest which would make the usage of pagination on the frontend better or easier to use as it is sorted from oldest to newest using created_at as a more efficective sort parameter

3. without filtering: 
![without_filter](https://user-images.githubusercontent.com/65228354/206713852-a3a1a5ef-5133-4282-b595-4a8d83d07ce8.png)

made use of raw_query to execute filtering




kindly review @mikengr @AI-fae 