### PR TITLE
corrected get messages endpoint and paginator.py to return an empty a…

### DIFF
--- a/backend/endpoints/messages.py
+++ b/backend/endpoints/messages.py
@@ -308,12 +308,6 @@ async def get_messages(
         endpoint=f"/api/v1/org/{org_id}/rooms/{room_id}/messages",
     )
 
-    if response == []:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Room does not exist or no message found",
-        )
-
     if response is None:
         raise HTTPException(
             status_code=status.HTTP_424_FAILED_DEPENDENCY,
@@ -344,6 +338,73 @@ async def get_messages(
 )   
 
 async def get_single_message(org_id: str, room_id: str, message_id: str):
+    """Fetches a single message.
+
+    Args:
+        org_id (str): A unique identifier of an organization.
+        room_id (str): A unique identifier of the room where messages are fetched from.
+        message_id (str): The id of the message to be retrieved.
+
+    Returns:
+    
+        A dict containing a list of message objects.
+        {
+            "status": "success",
+            "message": "Messages retrieved",
+            "data": {
+                "_id": "61e75bc065934b58b8e5d223",
+                "created_at": "2022-02-02 17:57:02.630439",
+                "edited": true,
+                "emojis": [],
+                "files": [],
+                "message_id": null,
+                "org_id": "637f6f28601ce3fc5dc738f3",
+                "richUiData": {
+                "blocks": [
+                    {
+                        "data": {},
+                        "depth": 0,
+                        "entityRanges": [],
+                        "inlineStyleRanges": [],
+                        "key": "4c3f3",
+                        "text": "sdfuigd",
+                        "type": "unstyled"
+                    }
+                ],
+                "entityMap": {}
+            },
+            "room_id": "637f6f2d601ce3fc5dc738f5",
+            "saved_by": [],
+            "sender_id": "637f6f28601ce3fc5dc738f4",
+            "threads": [
+                {
+                "emojis": [],
+                "richUiData": {
+                    "blocks": [
+                        {
+                            "data": {},
+                            "depth": 0,
+                            "entityRanges": [],
+                            "inlineStyleRanges": [],
+                            "key": "f3s6p",
+                            "text": "It's just Mykie here again!",
+                            "type": "unstyled"
+                        }
+                    ],
+                    "entityMap": {}
+                },
+                "sender_id": "637f6f28601ce3fc5dc738f4",
+                "thread_id": "1504c7aa-77d7-11ed-ae42-ec8eb54be004",
+                "timestamp": 1669917458839
+            }
+        ],
+        "timestamp": 1669999250973
+    }
+}
+
+    Raises:
+        HTTPException [424]: Zc Core failed"""
+
     response = await get_message(org_id, room_id, message_id)
 
     if response == []:

--- a/backend/utils/paginator.py
+++ b/backend/utils/paginator.py
@@ -9,9 +9,12 @@ async def off_set(page: int, size: int):
 async def page_urls(page: int, size: int, org_id: int, room_id: int, endpoint: str):
 
     DB = DataStorage(org_id)
-    total_count = len(
-        await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id})
-    )
+    messages = await DB.read(settings.MESSAGE_COLLECTION, query={"room_id": room_id})
+
+    if messages is None:
+        total_count = 0
+    else:
+        total_count = len(messages)
 
     paging = {}
 


### PR DESCRIPTION
Problem 1:
GET messages endpoint was returning ‘internal server error’ for rooms with no messages. 

Fix:
I fixed this in the paginator.py file by putting a check for if messages is None before going on with the pagination logic.

Problem 2:
After the first fix, the endpoint would return a “detail: room does not exist or no message found” message for a room with no messages.
![B87782B5-99AD-471C-95E2-E7DCFB0EF693](https://user-images.githubusercontent.com/82163647/206875345-402462f9-29b3-4cfd-8079-2e3297db64d3.jpeg)

Fix:
I changed this to return the same data structure as when a message exists, but with the data array empty as seen below.

![A425746C-B6DE-440C-B13E-8F0A8B6D5FFD](https://user-images.githubusercontent.com/82163647/206875321-f36f9908-4769-45b8-9e1c-8cf41ac996fa.jpeg)
