### PR TITLE
fix: datetime value bug in message request and refactor threads logic

### DIFF
--- a/backend/schema/message.py
+++ b/backend/schema/message.py
@@ -89,28 +89,6 @@ class MessageRequest(BaseModel):
     timestamp: int = 0
     created_at: str = str(datetime.utcnow())
 
-    @classmethod
-    def as_form(
-        cls,
-        sender_id: str = Form(str),
-        emojis: List[Emoji] = Form([]),
-        richUiData: Any = Form({}),
-        files: List[AnyHttpUrl] = Form([]),
-        saved_by: List[str] = Form([]),
-        timestamp: int = Form(int),
-        created_at: str = Form(str(datetime.utcnow())),
-    ):
-        return cls(
-            sender_id=sender_id,
-            emojis=emojis,
-            richUiData=richUiData,
-            files=files,
-            saved_by=saved_by,
-            timestamp=timestamp,
-            created_at=created_at
-        )
-
-
 class Thread(MessageRequest):
     """Provide structure for the thread schema
 

--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 from typing import Any, Optional
 from config.settings import settings
 from schema.message import Message
@@ -155,7 +155,7 @@ async def create_message(org_id: str, message: Message) -> dict[str, Any]:
     """
 
     db = DataStorage(org_id)
-
+    message.created_at = str(datetime.utcnow())
     return await db.write(settings.MESSAGE_COLLECTION, message.dict())
 
 

--- a/backend/utils/threads_utils.py
+++ b/backend/utils/threads_utils.py
@@ -4,14 +4,14 @@ import json
 from typing import Any, Optional
 from schema.message import Thread
 from schema.message import Message, MessageRequest
-
+from datetime import datetime
 from utils.db import DataStorage
 from utils.message_utils import get_message ,update_message
 from config.settings import settings
 
 # List all messages in a thread
 
-async def get_messages_in_thread(org_id, room_id, message_id):
+async def get_message_threads(org_id, room_id, message_id):
     """Retrives all the messages in a thread.
 
     Args:
@@ -25,13 +25,11 @@ async def get_messages_in_thread(org_id, room_id, message_id):
     """
 
     # fetch message parent of the thread
-    DB = DataStorage(org_id)
-    messages = await get_message(org_id, room_id, message_id)
-    return messages["threads"]
+    message = await get_message(org_id, room_id, message_id)
+    return message["threads"]
 
 
-
-async def add_message_to_thread(org_id, room_id, message_id, request):
+async def add_message_to_thread_list(org_id, room_id, message_id, request: Thread):
     """Adds a message to a thread.
 
     Args:
@@ -51,18 +49,15 @@ async def add_message_to_thread(org_id, room_id, message_id, request):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Message not found"
         )
-
-    payload = request.dict(exclude_unset=True)
-
     del message["_id"]
 
-    thread= message["threads"]
+    thread_message = request.dict(exclude_unset=True)
+    thread_message["thread_id"] = str(uuid.uuid1())
+    thread_message["created_at"] = str(datetime.utcnow())
 
-    payload["thread_id"] = str(uuid.uuid1())
-
-    thread.append(payload)
+    message["threads"].insert(0, thread_message)
    
     response = await update_message(org_id, message_id, message)
     
-    return response, payload
+    return response, thread_message
 


### PR DESCRIPTION
* Assigned the `datetime.utcnow()` to the `created_at` field of the message object  before `db.write` is called rather than using the value from the request object

* Refactored the post thread messages endpoint with proper functions and variable naming. Also updated the `add_to_threads_list` function to insert threads at the beginning of the list rather than appending at the end.