### PR TITLE
feat: added endpoint to update a thread message

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,6 @@ colorama==0.4.4
 coverage==6.0.2
 distlib==0.3.3
 fastapi==0.70.0
-fastapi-pagination==0.9.1
 filelock==3.3.1
 h11==0.12.0
 httpcore==0.15.0
@@ -46,7 +45,6 @@ python-dateutil==2.8.2
 python-dotenv==0.19.1
 python-multipart==0.0.5 
 PyYAML==6.0
-regex==2021.10.23
 requests==2.26.0
 rfc3986==1.5.0
 six==1.16.0

--- a/backend/utils/message_utils.py
+++ b/backend/utils/message_utils.py
@@ -179,18 +179,19 @@ async def update_message(
     return await db.update(settings.MESSAGE_COLLECTION, message_id, message)
 
 
-async def update_message_threads(
-    org_id: str, message_id: str, message: dict[str, Any]
-) -> dict[str, Any]:
-    """Updates a message document in the database.
-    Args:
-        org_id (str): The organization id where the message is being updated.
-        message_id (str): The id of the message to be edited.
-        message (dict[str, Any]): The new data.
-    Returns:
-        dict[str, Any]: The response returned by DataStorage's update method.
-    """
+# async def update_thread_message(
+#     org_id: str, thread_id: str, thread_message: dict[str, Any]
+# ) -> dict[str, Any]:
+#     """
+#     Updates a message document in the database.
+#     Args:
+#         org_id (str): The organization id where the message is being updated.
+#         message_id (str): The id of the message to be edited.
+#         message (dict[str, Any]): The new data.
+#     Returns:
+#         dict[str, Any]: The response returned by DataStorage's update method.
+#     """
 
-    db = DataStorage(org_id)
+#     db = DataStorage(org_id)
 
-    return await db.update(settings.MESSAGE_COLLECTION, message_id, message)
+#     return await db.update(settings.MESSAGE_COLLECTION, thread_id, thread_message)

--- a/backend/utils/threads_utils.py
+++ b/backend/utils/threads_utils.py
@@ -6,7 +6,7 @@ from schema.message import Thread
 from schema.message import Message, MessageRequest
 from datetime import datetime
 from utils.db import DataStorage
-from utils.message_utils import get_message ,update_message
+from utils.message_utils import get_message, update_message
 from config.settings import settings
 
 # List all messages in a thread
@@ -18,7 +18,7 @@ async def get_message_threads(org_id, room_id, message_id):
         org_id (str): The organization id where the message is being updated.
         room_id (str): The id of the room the message was sent in.
         message_id (str): The id of the message to be edited.
-        
+
 
     Returns:
         [dict]: Returns an array of message objects.
@@ -44,7 +44,7 @@ async def add_message_to_thread_list(org_id, room_id, message_id, request: Threa
 
     # add message to a parent thread
     message = await get_message(org_id, room_id, message_id)
-    
+
     if not message:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Message not found"
@@ -56,8 +56,40 @@ async def add_message_to_thread_list(org_id, room_id, message_id, request: Threa
     thread_message["created_at"] = str(datetime.utcnow())
 
     message["threads"].insert(0, thread_message)
-   
+
     response = await update_message(org_id, message_id, message)
-    
+
     return response, thread_message
 
+
+async def update_thread_message(
+    org_id: str, message_id: str, thread_id: str, payload: dict[str, Any], message: dict[str, Any]
+) -> dict[str, Any]:
+    """
+     Updates a thread object in message["threads"] then updates the message document in the database.
+     Args:
+         org_id (str): The organization id where the message is being updated.
+         message_id (str): The id of the message to be edited.
+         thread_id (str): The id of the thread to be edited
+         payload (dict[str, Any]): The new data.
+         message (dict[str, Any]): The message to be edited that has been loaded from the database
+     Returns:
+         dict[str, Any]: The response returned by DataStorage's update method.
+     """
+    threads = message["threads"]  # a list of thread objects
+
+    # to edit a thread object in the list of threads
+    for index in range(len(threads)):
+
+        if threads[index]["thread_id"] == thread_id and threads[index]["sender_id"] == payload["sender_id"]:
+            threads[index] = payload
+            threads[index]["edited"] = True
+
+            del message["_id"]
+
+            db = DataStorage(org_id)
+            return await db.update(settings.MESSAGE_COLLECTION, message_id, message)
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail="Thread message not found or sender is not authorised to edit this message"
+    )


### PR DESCRIPTION
Implemented update threads endpoint.

Note:
This is a temporary solution as it uses an O(n) algorithm while we review a better way to implement threads (possibly as a collection of it's own).
Also when testing the PUT /Update Message endpoint, the thread_id must be included in the request body.

@mikengr @zxenonx @AI-fae 